### PR TITLE
make compression level adjustable

### DIFF
--- a/README.md
+++ b/README.md
@@ -117,7 +117,7 @@ You need 3 functions in your hook for it to be properly initialized by the scrip
 
 Please keep in mind that this project has minimal support for automation and very little support will be provided. In order to export contacts, you still need to have physical access to the device you're backing up as an "unattended mode" for the companion app hasn't been implemented yet.
 
-There are 9 environment variables that control what the script does without user input:
+There are 10 environment variables that control what the script does without user input:
 
 1. `unattended_mode` - Instead of waiting for a key press, sleeps for 5 seconds. Can be any value.
 2. `selected_action` - What the script should do when run. Possible values are `Backup` and `Restore` (case sensitive).
@@ -128,6 +128,7 @@ There are 9 environment variables that control what the script does without user
 7. `use_hooks` - Whether to use hooks or not. Possible values are `yes` or `no` (case sensitive).
 8. `data_erase_choice` - Whether to securely erase temporary files or not. Possible values are `Fast`, `Slow` and `Extra Slow` (case sensitive). The value of this variable is ignored if the command `srm` isn't present on your computer.
 9. `discouraged_disable_archive` - Disables the creation of a backup archive, only creates a backup *directory* with no compression, encryption or other features. This is not recommended, although some may find it useful to deduplicate backups and save space. Restoring backups created with this option enabled is not supported by default; you must manually create an archive from the backup directory and then restore it. Possible values are `yes` or `no` (case sensitive).
+10. `compression_level` - One of 0, 1, 3, 5, 7, 9. Where 9 is the best an slowest copression and 0 is no compression and the fastest level. If most of your data is already compressed, for example jpg pictures or mp3 videos, you will not loose much volume by compressing it. 
 
 Examples:
 

--- a/backup.sh
+++ b/backup.sh
@@ -95,6 +95,20 @@ fi
 
 clear
 
+if [ ! -v compression_level ]; then
+  cecho "Choose the compression level."
+  cecho "- 0 is no compression, and is the fastest."
+  cecho "- 9 is the slowest, but provides the best compression."
+  cecho "- 7 was the previous default"
+  cecho "Press Enter to pick your preferred compression level."
+  wait_for_enter
+
+  compression_levels=( '0' '1' '2' '3' '4' '5' '6' '7' '8' '9' )
+  select_option_from_list "Choose the compression level" compression_levels[@] compression_level
+fi
+
+clear
+
 if [ ! -v use_hooks ]; then
   cecho "Would you like to use hooks?"
   cecho "Choose 'no' if you don't understand this question, or don't want to load hooks."

--- a/backup.sh
+++ b/backup.sh
@@ -98,12 +98,14 @@ clear
 if [ ! -v compression_level ]; then
   cecho "Choose the compression level."
   cecho "- 0 is no compression, and is the fastest."
+  cecho "- 3 is fast compression."
+  cecho "- 5 is normal compression, which is a balance between speed and file size."
+  cecho "- 7 is maximum compression, it was the previous default."
   cecho "- 9 is the slowest, but provides the best compression."
-  cecho "- 7 was the previous default"
   cecho "Press Enter to pick your preferred compression level."
   wait_for_enter
 
-  compression_levels=( '0' '1' '2' '3' '4' '5' '6' '7' '8' '9' )
+  compression_levels=( '0' '1' '3' '5' '7' '9' )
   select_option_from_list "Choose the compression level" compression_levels[@] compression_level
 fi
 

--- a/functions/backup_func.sh
+++ b/functions/backup_func.sh
@@ -122,7 +122,7 @@ function backup_func() {
     # -bb3: verbose logging
     # The undefined variable (archive_password) is set by the user if they're using unattended mode
     declare backup_archive="$archive_path/open-android-backup-$(date +%m-%d-%Y-%H-%M-%S).7z"
-    retry 5 7z a -p"$archive_password" -mhe=on -mx=7 -bb3 "$backup_archive" backup-tmp/*
+    retry 5 7z a -p"$archive_password" -mhe=on -mx=$compression_level -bb3 "$backup_archive" backup-tmp/*
   fi
 
   # We're not using 7-Zip's -sdel option (delete files after compression) to honor the user's choice to securely delete temporary files after a backup


### PR DESCRIPTION
I added a simple method to use different compression levels. I used level 0 (no compression) and it made only little difference in file size:

-rw-rw-r--  1 eggert eggert  51G Feb 23 14:01 open-android-backup-02-23-2024-11-52-03.7z # default
-rw-rw-r--  1 eggert eggert  53G Feb 23 19:00 open-android-backup-02-23-2024-18-23-18.7z # level 0

but it is significantly faster. 7z is always used as before, it just uses the compression level.