### PR TITLE
removed wildcard from adb push for restoring internal storage

### DIFF
--- a/functions/restore_func.sh
+++ b/functions/restore_func.sh
@@ -108,7 +108,7 @@ function restore_func() {
 
   # Restore internal storage
   cecho "Restoring internal storage."
-  adb push ./backup-tmp/Storage/* /storage/emulated/0
+  adb push ./backup-tmp/Storage/ /storage/emulated/0/
 
   # Restore contacts
   cecho "Pushing backed up contacts to device."


### PR DESCRIPTION
removed wildcard from adb push for restoring internal storage, as it lead to an error 
> failed to copy './backup-tmp/Storage/40217682857069113.jpg' to './backup-tmp/Storage/Android': secure_mkdirs() failed: No such file or directory" 

for me. In my estimation, adb does not handle wildcards very gracefully, but it could have been that the a non-standard filename (whitespace or non-ascii) in the backup was the problem. With the fix, it still does not create a subdirectory Storage, but just copies the contents. 