### PR TITLE
Allow backup with a pure wireless setup. 

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -6,3 +6,5 @@ hooks.sh
 .vscode
 .idea
 .cxx
+*~
+\#*#

--- a/backup.sh
+++ b/backup.sh
@@ -15,20 +15,28 @@ while [ -h "$SOURCE" ]; do # resolve $SOURCE until the file is no longer a symli
 done
 DIR="$( cd -P "$( dirname "$SOURCE" )" && pwd )"
 
-# ---
-
 # Load all functions in ./functions
 for f in "$DIR"/functions/*.sh; do source "$f"; done
 
-check_adb_connection
-
+mode=Wireless
 if [ ! -v mode ]; then
   modes=( 'Wired' 'Wireless' )
   select_option_from_list "Choose the connection method. Wireless is experimental and still requires a device connected for pairing." modes[@] mode
 fi
 
+#For now require connection to be pre-existing for wireless mode.
+if [ "$mode" = 'Wireless' ]; then
+  do_connection='false'
+else
+  do_connection='true'
+fi
+
 
 check_install
+
+# ---
+
+check_adb_connection
 
 if [ "$mode" = 'Wireless' ]; then
   # See ./functions/wireless_connection.sh

--- a/backup.sh
+++ b/backup.sh
@@ -7,56 +7,6 @@ set -e
 # TODO: load this dynamically, i.e. configure our build system to automatically update the APP_VERSION
 APP_VERSION="v1.2.0"
 
-# We use whiptail for showing dialogs.
-# Whiptail is used similarly as dialog, but we can't install it on macOS using Homebrew IIRC.
-# So we need to fall back to dialog if whiptail is not available.
-# Check if whiptail is installed
-if command -v whiptail &> /dev/null; then
-  # Whiptail is installed, no action needed. Do nothing.
-  :
-else
-  # Check if dialog is installed
-  if command -v dialog &> /dev/null; then
-    echo "Whiptail is not installed, but dialog is. Defining whiptail as a function that calls dialog."
-    # Define whiptail as a function that calls dialog with the same arguments
-    whiptail() {
-      dialog "$@"
-    }
-  else
-    # Neither whiptail nor dialog are installed
-    echo "Neither whiptail nor dialog are installed, can't continue. Please refer to the README for usage instructions."
-    exit 1
-  fi
-fi
-
-# Check if other dependencies are installed: adb, tar, pv, 7z, bc, timeout
-# srm is optional so we don't check for it
-commands=("tar" "pv" "7z" "adb" "bc")
-
-# Add zenity to the list of commands if we're running in WSL
-if [ "$(uname -r | sed -n 's/.*\( *Microsoft *\).*/\1/ip')" ]; then
-  commands+=("zenity")
-fi
-
-# Add gtimeout to the list of commands if we're running on macOS
-if [ "$(uname)" = "Darwin" ]; then
-  commands+=("gtimeout")
-else
-  # For the rest of the systems, we use the standard timeout command
-  commands+=("timeout")
-fi
-
-for cmd in "${commands[@]}"
-do
-  # adb is a function in WSL so we're using type instead of command -v
-  if ! type "$cmd" &> /dev/null
-  then
-    echo "$cmd is not available, can't continue. Please refer to the README for usage instructions."
-    exit 1
-  fi
-done
-
-
 SOURCE="${BASH_SOURCE[0]}"
 while [ -h "$SOURCE" ]; do # resolve $SOURCE until the file is no longer a symlink
   DIR="$( cd -P "$( dirname "$SOURCE" )" && pwd )"
@@ -70,18 +20,15 @@ DIR="$( cd -P "$( dirname "$SOURCE" )" && pwd )"
 # Load all functions in ./functions
 for f in "$DIR"/functions/*.sh; do source "$f"; done
 
-# Ensure that there's enough space on the device
-# TODO: Check this based on the size of the backup (or the device's storage capacity) instead of a hardcoded value of 100GB
-if ! enough_free_space "."; then
-  cecho "Less than 100GB of free space available in the current directory. You may encounter issues if working with large backups."
-fi
-
 check_adb_connection
 
 if [ ! -v mode ]; then
   modes=( 'Wired' 'Wireless' )
   select_option_from_list "Choose the connection method. Wireless is experimental and still requires a device connected for pairing." modes[@] mode
 fi
+
+
+check_install
 
 if [ "$mode" = 'Wireless' ]; then
   # See ./functions/wireless_connection.sh

--- a/functions/check_install.sh
+++ b/functions/check_install.sh
@@ -1,0 +1,59 @@
+function check_install () {
+  # We use whiptail for showing dialogs.
+  # Whiptail is used similarly as dialog, but we can't install it on macOS using Homebrew IIRC.
+  # So we need to fall back to dialog if whiptail is not available.
+  # Check if whiptail is installed
+  if command -v whiptail &> /dev/null; then
+    # Whiptail is installed, no action needed. Do nothing.
+    :
+  else
+    # Check if dialog is installed
+    if command -v dialog &> /dev/null; then
+      echo "Whiptail is not installed, but dialog is. Defining whiptail as a function that calls dialog."
+      # Define whiptail as a function that calls dialog with the same arguments
+      whiptail() {
+	dialog "$@"
+      }
+    else
+      # Neither whiptail nor dialog are installed
+      echo "Neither whiptail nor dialog are installed, can't continue. Please refer to the README for usage instructions."
+      exit 1
+    fi
+  fi
+
+  # Check if other dependencies are installed: adb, tar, pv, 7z, bc, timeout
+  # srm is optional so we don't check for it
+  commands=("tar" "pv" "7z" "adb" "bc")
+
+
+  # Add zenity to the list of commands if we're running in WSL
+  if [ "$(uname -r | sed -n 's/.*\( *Microsoft *\).*/\1/ip')" ]; then
+    commands+=("zenity")
+  fi
+
+  # Add gtimeout to the list of commands if we're running on macOS
+  if [ "$(uname)" = "Darwin" ]; then
+    commands+=("gtimeout")
+  else
+    # For the rest of the systems, we use the standard timeout command
+    commands+=("timeout")
+  fi
+
+  for cmd in "${commands[@]}"
+  do
+    # adb is a function in WSL so we're using type instead of command -v
+    if ! type "$cmd" &> /dev/null
+    then
+      echo "$cmd is not available, can't continue. Please refer to the README for usage instructions."
+      exit 1
+    fi
+  done
+
+
+  # Ensure that there's enough space on the device
+  # TODO: Check this based on the size of the backup (or the device's storage capacity) instead of a hardcoded value of 100GB
+  if ! enough_free_space "."; then
+    cecho "Less than 100GB of free space available in the current directory. You may encounter issues if working with large backups."
+  fi
+
+}

--- a/functions/helper.sh
+++ b/functions/helper.sh
@@ -39,7 +39,11 @@ function cecho() {
 }
 
 function check_adb_connection() {
-  adb kill-server &> /dev/null || true
+  #FIXME: this breaks ability to do pure wireless. Reinstate to allow wireless initiated using USB.
+  if [ "$do_connection" = "true" ]
+  then
+    adb kill-server &> /dev/null || true
+  fi
   cecho "Please enable developer options and USB debugging on your device, connect it to your computer and set it to file transfer mode. Then, press Enter to continue."
   cecho "Samsung users may need to temporarily disable 'Auto Blocker' first."
   wait_for_enter

--- a/functions/wireless_connection.sh
+++ b/functions/wireless_connection.sh
@@ -15,24 +15,27 @@ function wireless_connection() {
   # `device_ip` is the device ip address *without the port*, available on all devices.
   # `device_ip_port` is the device ip address AND port, available on android 11+.
   android_version="$(adb shell getprop ro.build.version.release | tr -d '\r' | bc)"
-  if (( android_version > 10 )); then
-    cecho "Running on Android 11 or higher - automatic wireless connections are not supported."
-    cecho "Please open the settings app on your device, and search for 'Wireless debugging'. Enable the option, press 'Pair device with pairing code', and enter the IP address and port of your device below:"
-    # TODO: use get_text_input instead of read
-    #get_text_input "Device IP & Port:" device_ip_port "$device_ip"
-    read -p "Pairing IP address & Port: " device_ip_port
-    cecho "Pairing device..."
-    adb pair "$device_ip_port"
-    cecho "You now have to enter the IP address and port that's shown in the settings app (not the one shown in the pairing screens)."
-    read -p "Device IP address & Port: " device_ip_port
-    adb connect "$device_ip_port" # this is necessary yet not mentioned in the official documentation
-  else # Running on Android 10 or lower
-    cecho "Establishing connection..."
-    adb tcpip 5353
-    sleep 5
-    adb connect "$device_ip:5353"
-  fi
 
+
+  if [ "$do_connection" = "true" ]; then
+    if (( android_version > 10 )); then
+      cecho "Running on Android 11 or higher - automatic wireless connections are not supported."
+      cecho "Please open the settings app on your device, and search for 'Wireless debugging'. Enable the option, press 'Pair device with pairing code', and enter the IP address and port of your device below:"
+      # TODO: use get_text_input instead of read
+      #get_text_input "Device IP & Port:" device_ip_port "$device_ip"
+      read -p "Pairing IP address & Port: " device_ip_port
+      cecho "Pairing device..."
+      adb pair "$device_ip_port"
+      cecho "You now have to enter the IP address and port that's shown in the settings app (not the one shown in the pairing screens)."
+      read -p "Device IP address & Port: " device_ip_port
+      adb connect "$device_ip_port" # this is necessary yet not mentioned in the official documentation
+    else # Running on Android 10 or lower
+      cecho "Establishing connection..."
+      adb tcpip 5353
+      sleep 5
+      adb connect "$device_ip:5353"
+    fi
+  fi
   cecho "Please unplug your device from the computer, and press Enter to continue."
   wait_for_enter
   adb devices


### PR DESCRIPTION
If there is a pure wireless setup, then it's impossible to connect to the phone and get it's IP address and port configuration until the debugging connection has been set up. Also, every time a new connection is made, the user has to do manual work to read the security code from the phone and give it to the pairing command. In this situation, I think it makes more sense to have the user set up a static connection and to leave that connection in place all the time. 

This patch reorganizes the startup so that the wireless vs USB question happens as soon as possible and then disables killing and restarting the adb server if wireless is to be used. 

I have not tested this with the old (pre Android 11) wireless setup and I *think* that the patch breaks that. Android 11 is already EOL, so my feeling is that support for it should be removed with a documentation pointer to the last version of `open-android-backup` that it would work with. If I get some feedback about this I may update the patch, either to make the old version work as it used to or to or to delete the old code. 